### PR TITLE
目前不支持带密码的 sentinel

### DIFF
--- a/src/carmine_sentinel/core.clj
+++ b/src/carmine_sentinel/core.clj
@@ -139,6 +139,8 @@
   [raw-states]
   (->> raw-states
        (map (partial apply hash-map))
+       ;; 这里取到 sentinel 列表后，构造出来的只有 host 和 port，缺少 password
+       ;; 所以如果 sentinel 只配置了 A B 两个 Sentinel 且分别提供了密码，但实际有 A B C 三个 sentinel，那连接 C 的时候因为不会带着 password 导致会连不上
        (map (fn [{:strs [ip port]}]
               {:host ip
                :port (Integer/valueOf ^String port)}))))


### PR DESCRIPTION
这个 PR 实际是个 issue。

目前这个库还不支持给 sentinel 配置密码。原因写在 comment 里了。

而 sentinel 管理的 redis 是支持密码的 :scream:。