### PR TITLE
连接 sentinel 支持密认证

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,12 +189,31 @@ At last, carmine-sentinel will refresh the sentinel instance list by the respons
 
 ## Testing
 
-Running the Makefile tests requires having `make`, `lein` and a Linux or MacOS machine.
-The test scenario in the is comprised of three sentinels and one master.
+We use docker-compose to facilitate testing and development. But due
+to sentinel auto-discovery is not friendly to docker, we have to use
+external ip (such as 192.68.1.x) instead of loopback interface
+(127.0.0.1) to setup the redis ip.
 
-To run the tests simply run in shell:
-```shell
-make test
+First, setup the env for docker setup:
+
+```sh
+> cat env.sh
+export HOST_IP=$(ipconfig getifaddr en0)
+export SENTINEL_SPECS="foobar@$HOST_IP:5000,foobar@$HOST_IP:5001,foobar@$HOST_IP:5002"
+export REDIS_SPECS="foobar@$HOST_IP:6379,foobar@$HOST_IP:6380"
+> source env.sh
+```
+
+Then, bring up redis cluster by docker-compose:
+
+```sh
+docker-compose up -d
+```
+
+At last, run test:
+
+```sh
+lein test
 ```
 
 ## License

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,65 @@
+version: '2'
+
+volumes:
+    data: {}
+
+networks: {}
+
+services:
+    redis:
+      image: redis:6.0-alpine
+      ports:
+        - "6379:6379"
+      command:
+        - redis-server
+        - --requirepass foobar
+        - --masterauth foobar
+
+    redis1:
+      image: redis:6.0-alpine
+      ports:
+        - "6380:6379"
+      command:
+        - redis-server
+        - --requirepass foobar
+        - --masterauth foobar
+        - --slaveof ${HOST_IP} 6379
+        - --slave-announce-ip ${HOST_IP}
+        - --slave-announce-port 6380
+
+    sentinel:
+      build: ./sentinel
+      # export HOST_IP=$(ipconfig getifaddr en0)
+      environment:
+        - "MASTER_NAME=mymaster"
+        - "MASTER_PASS=foobar"
+        - "HOST_IP=${HOST_IP}"
+      ports:
+        - "5000:5000"
+      command:
+        - --requirepass foobar
+        - --port 5000
+
+    sentinel1:
+      build: ./sentinel
+      environment:
+        - "MASTER_NAME=mymaster"
+        - "MASTER_PASS=foobar"
+        - "HOST_IP=${HOST_IP}"
+      ports:
+        - "5001:5000"
+      command:
+        - --requirepass foobar
+        - --port 5000
+
+    sentinel2:
+      build: ./sentinel
+      environment:
+        - "MASTER_NAME=mymaster"
+        - "MASTER_PASS=foobar"
+        - "HOST_IP=${HOST_IP}"
+      ports:
+        - "5002:5000"
+      command:
+        - --requirepass foobar
+        - --port 5000

--- a/sentinel/Dockerfile
+++ b/sentinel/Dockerfile
@@ -1,0 +1,5 @@
+FROM redis:6.0-alpine
+
+EXPOSE 5000
+COPY entrypoint.sh /usr/local/bin/sentinel-entrypoint.sh
+ENTRYPOINT ["sentinel-entrypoint.sh"]

--- a/sentinel/entrypoint.sh
+++ b/sentinel/entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+set -ex
+
+MASTER_NAME=${MASTER_NAME}
+MASTER_PORT=${MASTER_PORT:-"6379"}
+QUORUM=${QUORUM:-1}
+DOWN_AFTER_MS=${AFTER_DOWN_MS:-18000}
+FAILOVER_MS=${FAILOVER_MS:-180000}
+
+mkdir -p /etc/redis
+cat <<EOF > /etc/redis/sentinel.conf
+sentinel monitor $MASTER_NAME $HOST_IP $MASTER_PORT $QUORUM
+sentinel down-after-milliseconds $MASTER_NAME $DOWN_AFTER_MS
+sentinel parallel-syncs $MASTER_NAME 1
+sentinel failover-timeout $MASTER_NAME $FAILOVER_MS
+sentinel announce-ip $HOST_IP
+EOF
+
+if [ ! -z "$MASTER_PASS" ]; then
+    echo "sentinel auth-pass $MASTER_NAME $MASTER_PASS" >> /etc/redis/sentinel.conf
+fi
+
+chown -R redis:redis /etc/redis
+
+exec docker-entrypoint.sh redis-server /etc/redis/sentinel.conf --sentinel $@

--- a/test/carmine_sentinel/core_test.clj
+++ b/test/carmine_sentinel/core_test.clj
@@ -26,69 +26,69 @@
 ;;; requirepass "foobar"
 
 
-(def token "foobar")
-(def host "127.0.0.1")
-(def conn {:pool {}
-           :spec {:password token}
-           :sentinel-group :group1
-           :master-name "mymaster"})
+(defn- get-env
+  ([k]
+   (get-env k nil))
+  ([k default]
+   (or (System/getenv k)
+       default)))
+
+(def sentinel-master "mymaster")
+(def sentinel-group :group1)
+(def redis-master-spec
+  (->> (get-env "REDIS_MASTER_SPEC" "127.0.0.1:6379")
+       parse-specs
+       first))
+(def sentinel-specs
+  (->> (get-env "SENTINEL_SPECS" "127.0.0.1:5000")
+       parse-specs))
+(def server-conn
+  {:pool {}
+   :spec (dissoc redis-master-spec :host :port)
+   :sentinel-group sentinel-group
+   :master-name sentinel-master})
 
 (set-sentinel-groups!
- {:group1
-  {:specs [{:host host :port 5000 :password token}
-           {:host host :port 5001 :password token}
-           {:host host :port 5002 :password token}]}})
+ {sentinel-group
+  {:specs sentinel-specs}})
 
 
 (deftest resolve-master-spec
   (testing "Try to resolve the master's spec using the sentinels' specs"
     (is (=
-         [{:password "foobar", :host "127.0.0.1", :port 6379} ()]
+         [redis-master-spec ()]
          (let [server-conn     {:pool {},
-                                :spec {:password "foobar"},
+                                :spec (dissoc redis-master-spec :host :port),
                                 :sentinel-group :group1,
-                                :master-name "mymaster"}
-               specs           [{:host "127.0.0.1", :port 5002, :password "foobar"}
-                                {:host "127.0.0.1", :port 5001, :password "foobar"}
-                                {:host "127.0.0.1", :port 5000, :password "foobar"}]
-               sentinel-group :group1
-               master-name    "mymaster"]
+                                :master-name sentinel-master}
+               specs           sentinel-specs]
            (@#'carmine-sentinel.core/try-resolve-master-spec
-            server-conn specs sentinel-group master-name))))))
+            server-conn specs sentinel-group sentinel-master))))))
 
 (deftest subscribing-all-sentinels
   (testing "Check if sentinels are subscribed to correctly"
-    (is (=
-         [{:password "foobar", :port 5002, :host "127.0.0.1"}
-          {:password "foobar", :port 5001, :host "127.0.0.1"}
-          {:password "foobar", :port 5000, :host "127.0.0.1"}]
-         (let [sentinel-group :group1
-               master-name "mymaster"
-               server-conn conn]
+    (is (= sentinel-specs
            (@#'carmine-sentinel.core/subscribe-all-sentinels
             sentinel-group
-            master-name))))))
+            sentinel-master)))))
 
 (deftest asking-sentinel-master
   (testing "Testing if master is found through sentinel"
-    (is (= {:password "foobar", :host "127.0.0.1", :port 6379}
-           (let [sentinel-group :group1
-                 master-name "mymaster"
-                 server-conn conn]
-             (@#'carmine-sentinel.core/ask-sentinel-master sentinel-group
-              master-name
-              server-conn))))))
+    (is (= redis-master-spec
+           (@#'carmine-sentinel.core/ask-sentinel-master
+            sentinel-group
+            sentinel-master
+            server-conn)))))
 
 (deftest sentinel-redis-spec
   (testing "Trying to get redis spec by sentinel-group and master name"
-    (is (= {:password "foobar", :host "127.0.0.1", :port 6379}
-           (let [server-conn conn]
-             (get-sentinel-redis-spec (:sentinel-group server-conn)
-                                      (:master-name server-conn)
-                                      server-conn))))))
+    (is (= redis-master-spec
+           (get-sentinel-redis-spec (:sentinel-group server-conn)
+                                    (:master-name server-conn)
+                                    server-conn)))))
 
 (try
-  (defmacro test-wcar* [& body] `(wcar conn ~@body))
+  (defmacro test-wcar* [& body] `(wcar server-conn ~@body))
   (catch Exception e
     (println "WARNING: caught exception while defining wcar*,"
              "can occur when re-running tests in the same repl."

--- a/test/carmine_sentinel/core_test.clj
+++ b/test/carmine_sentinel/core_test.clj
@@ -35,10 +35,13 @@
 
 (def sentinel-master "mymaster")
 (def sentinel-group :group1)
-(def redis-master-spec
-  (->> (get-env "REDIS_MASTER_SPEC" "127.0.0.1:6379")
-       parse-specs
-       first))
+(def redis-specs
+  (->> (get-env "REDIS_SPECS" "127.0.0.1:6379")
+       parse-specs))
+;; assuming the first is master
+(def redis-master-spec (first redis-specs))
+(def redis-slave-specs (rest redis-specs))
+
 (def sentinel-specs
   (->> (get-env "SENTINEL_SPECS" "127.0.0.1:5000")
        parse-specs))
@@ -56,7 +59,7 @@
 (deftest resolve-master-spec
   (testing "Try to resolve the master's spec using the sentinels' specs"
     (is (=
-         [redis-master-spec ()]
+         [redis-master-spec redis-slave-specs]
          (let [server-conn     {:pool {},
                                 :spec (dissoc redis-master-spec :host :port),
                                 :sentinel-group :group1,


### PR DESCRIPTION

* 支持基于 docker-compose 的 redis 集群用于测试
* 修复测试用例
* 修复 sentinel 支持密码认证 close #1 