### PR TITLE
Refresh redis specs on conn failures

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
         - redis-server
         - --requirepass foobar
         - --masterauth foobar
+        - --slave-announce-ip ${HOST_IP}
+        - --slave-announce-port 6380
 
     redis1:
       image: redis:6.0-alpine

--- a/src/carmine_sentinel/core.clj
+++ b/src/carmine_sentinel/core.clj
@@ -233,7 +233,7 @@
     (throw (IllegalStateException.
             (format "Invalid spec found for %s %s" mn master))))
   (if (and prefer-slave? (seq slaves))
-    (slaves-balancer slaves)
+    ((or slaves-balancer first) slaves)
     master))
 
 (defn- ask-sentinel-master [sentinel-group master-name
@@ -310,8 +310,6 @@
    resolving cost."
   [sentinel-group master-name
    {:keys [prefer-slave? slaves-balancer]
-    :or {prefer-slave? false
-         slaves-balancer first}
     :as server-conn}]
   {:pre [(not (nil? sentinel-group))
          (not (empty? master-name))]}

--- a/src/carmine_sentinel/core.clj
+++ b/src/carmine_sentinel/core.clj
@@ -99,13 +99,17 @@
   (doseq [listener @event-listeners]
     (silently (listener event))))
 
+(defn reset-resolved-specs
+  [group master-name]
+  (swap! sentinel-resolved-specs dissoc-in [group master-name]))
+
 (defn- handle-switch-master [sg msg]
   (when (= "message" (first msg))
     (let [[master-name old-ip old-port new-ip new-port]
           (clojure.string/split (-> msg nnext first)  #" ")]
       (when master-name
         ;;remove last resolved spec
-        (swap! sentinel-resolved-specs dissoc-in [sg master-name])
+        (reset-resolved-specs sg master-name)
         (notify-event-listeners {:event "+switch-master"
                                  :old {:host old-ip
                                        :port (Integer/valueOf ^String old-port)}
@@ -213,7 +217,7 @@
                                    :slaves slaves})
           [master-spec slaves]))
       (catch Exception e
-        (swap! sentinel-resolved-specs dissoc-in [sentinel-group master-name])
+        (reset-resolved-specs sentinel-group master-name)
         (notify-event-listeners
          {:event "error"
           :sentinel-group sentinel-group
@@ -225,9 +229,9 @@
         nil))))
 
 (defn- choose-spec [mn master slaves prefer-slave? slaves-balancer]
-  (when (= :error master)
+  (when-not (:host master)
     (throw (IllegalStateException.
-            (str "Specs not found by master name: " mn))))
+            (format "Invalid spec found for %s %s" mn master))))
   (if (and prefer-slave? (seq slaves))
     (slaves-balancer slaves)
     master))
@@ -250,12 +254,11 @@
           ;;Try next sentinel
           (recur (next specs)
                  (conj tried-specs (first specs))))
-        ;;Tried all sentinel instancs, we don't get any valid specs
-        ;;Set a :error mark for this situation.
+        ;; Tried all sentinel instancs, we don't get any valid specs.
+        ;; Assuming the situation is temporary, lets reset specs so
+        ;; to resolve next time in.
         (do
-          (swap! sentinel-resolved-specs assoc-in [sentinel-group master-name]
-                 {:master :error
-                  :slaves :error})
+          (reset-resolved-specs sentinel-group master-name)
           (notify-event-listeners {:event "get-master-addr-by-name"
                                    :sentinel-group sentinel-group
                                    :master-name master-name
@@ -278,9 +281,9 @@
         (let [master (:master master-specs)]
           (when (not= :error master)
             (when (master-role? master)
-              (swap! sentinel-resolved-specs dissoc-in [group-id master-name]))))
+              (reset-resolved-specs group-id master-name))))
         (catch EOFException _
-          (swap! sentinel-resolved-specs dissoc-in [group-id master-name]))))))
+          (reset-resolved-specs group-id master-name))))))
 
 (defn register-listener!
   "Register listener for switching master.
@@ -391,9 +394,17 @@
   "
   {:arglists '([conn :as-pipeline & body] [conn & body])}
   [conn & sigs]
-  `(car/wcar
-    (update-conn-spec ~conn)
-    ~@sigs))
+  `(let [master# (:master-name ~conn)
+         group#  (:sentinel-group ~conn)]
+     (try
+       (car/wcar
+        (update-conn-spec ~conn)
+        ~@sigs)
+       (catch Exception ex#
+         ;; reset specs and refresh next time in.
+         (when master#
+           (reset-resolved-specs group# master#))
+         (throw ex#)))))
 
 (defmacro with-new-pubsub-listener
   "It's the same as taoensso.carmine/with-new-pubsub-listener,


### PR DESCRIPTION
根据 redis 官方推荐，在链接失败的时候，客户端应该重置 redis 节点信息，并尝试再次从 sentinel 获取新的节点信息。 https://redis.io/topics/sentinel-clients#handling-reconnections

这里尝试进行了以下优化：
* 无论是 master 还是 slave ，只要出现链接失败，就重置状态，并在下次请求时刷新节点信息；
* 在遍历所有 sentinels 都没有找到有效节点时，不设置无效的 master 节点，而是重置，并在下次请求时刷新节点信息；
* 修复默认的 slaves-balancer 没有透传导致的 NPE

上述优化，能够解决大部分客户端无法从故障中自我恢复的问题。但是另一方面，由于重置了状态，在故障恢复初期因为要从 sentinel 获取信息，会导致大量请求延时显著增加，不能快速响应错误（如果有断流器保护，则可以得到缓解）。