### PR TITLE
处理在传入的 spec 中改变特定 key 的问题

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,9 +2,9 @@
   :description "A Clojure library designed to connect redis by sentinel, make carmine to support sentinel."
   :url "https://github.com/killme2008/carmine-sentinel"
   :license {:name "Eclipse Public License"
-            :url "http://www.eclipse.org/legal/epl-v10.html"}
+            :url  "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.0"]
                  [com.taoensso/carmine "2.18.1"]]
   :deploy-repositories {"releases" :clojars}
   :plugins [[codox "0.6.8"]]
-  :warn-on-reflection true)
+  :global-vars {*warn-on-reflection* true})


### PR DESCRIPTION
有时候会在传入 spec 的时候，指定一些参数比如传入特定的 `db`。

当一个实例中使用多个不同的 db 时，可能就会触发这个问题，这个改动处理了它。